### PR TITLE
[autom8] Add missing cursor pointers on clickable elements and...

### DIFF
--- a/src/ui/gui/app.rs
+++ b/src/ui/gui/app.rs
@@ -3571,6 +3571,12 @@ impl Autom8App {
             Pos2::new(screen_rect.min.x + ui.available_width(), rect.max.y),
         );
 
+        // Set pointer cursor for enabled items on hover
+        if enabled && response.hovered() {
+            ui.ctx()
+                .output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
+        }
+
         ContextMenuItemResponse {
             clicked: response.clicked() && enabled,
             hovered: is_hovered,
@@ -3765,7 +3771,9 @@ impl Autom8App {
         } else {
             "Hide sidebar"
         };
-        response.on_hover_text(tooltip_text)
+        response
+            .on_hover_text(tooltip_text)
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
     }
 
     // ========================================================================
@@ -3890,7 +3898,9 @@ impl Autom8App {
             text_color,
         );
 
-        response.clicked()
+        response
+            .on_hover_cursor(egui::CursorIcon::PointingHand)
+            .clicked()
     }
 
     // ========================================================================
@@ -4060,6 +4070,9 @@ impl Autom8App {
                     Rounding::same(rounding::SMALL),
                     colors::SURFACE_HOVER,
                 );
+                // Set pointer cursor when hovering close button
+                ui.ctx()
+                    .output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
             }
 
             // Draw X icon
@@ -4069,7 +4082,7 @@ impl Autom8App {
                 colors::TEXT_MUTED
             };
             let x_center = close_rect.center();
-            let x_size = TAB_CLOSE_BUTTON_SIZE * 0.35;
+            let x_size = TAB_CLOSE_BUTTON_SIZE * 0.35 * if close_hovered { 1.15 } else { 1.0 };
             ui.painter().line_segment(
                 [
                     egui::pos2(x_center.x - x_size, x_center.y - x_size),
@@ -4307,6 +4320,9 @@ impl Autom8App {
                 Rounding::same(rounding::SMALL),
                 colors::SURFACE_HOVER,
             );
+            // Set pointer cursor when hovering close button
+            ui.ctx()
+                .output_mut(|o| o.cursor_icon = egui::CursorIcon::PointingHand);
         }
 
         // Draw X icon
@@ -4316,7 +4332,7 @@ impl Autom8App {
             colors::TEXT_MUTED
         };
         let x_center = close_rect.center();
-        let x_size = TAB_CLOSE_BUTTON_SIZE * 0.3;
+        let x_size = TAB_CLOSE_BUTTON_SIZE * 0.3 * if close_hovered { 1.15 } else { 1.0 };
 
         ui.painter().line_segment(
             [
@@ -7135,6 +7151,9 @@ impl Autom8App {
         let is_hovered = response.hovered();
         let was_clicked = response.clicked();
         let was_secondary_clicked = response.secondary_clicked();
+
+        // Set pointer cursor for project rows
+        response.on_hover_cursor(egui::CursorIcon::PointingHand);
 
         // Draw row background with hover and selected states
         let bg_color = if is_selected {


### PR DESCRIPTION
## Summary

Add missing cursor pointers on clickable elements and improve hover feedback throughout the egui GUI. These are small, low-risk changes that improve perceived interactivity.

All changes are in `src/ui/gui/app.rs`. Each fix is a one-liner or small conditional tweak.

## Changes

### US-001: Add cursor pointer to sidebar toggle button

Add pointer cursor when hovering the sidebar collapse/expand button.

**Acceptance Criteria:**

- [ ] Cursor changes to pointing hand when hovering the sidebar toggle button
- [ ] Add `.on_hover_cursor(egui::CursorIcon::PointingHand)` to the response chain at line ~3768

**Notes:**

In `render_sidebar_toggle_button`, chain onto the existing `response.on_hover_text(tooltip_text)` return.

### US-002: Add cursor pointer to sidebar navigation items

Add pointer cursor when hovering sidebar nav items (Active Runs, Projects, etc).

**Acceptance Criteria:**

- [ ] Cursor changes to pointing hand when hovering any sidebar navigation item
- [ ] Modify `render_sidebar_item` to return `response.on_hover_cursor(...)` instead of `response.clicked()`

**Notes:**

At line ~3893, change `response.clicked()` to store response, add cursor, then return clicked state.

### US-003: Add cursor pointer to context menu items

Add pointer cursor when hovering enabled context menu items. Disabled items should not show pointer.

**Acceptance Criteria:**

- [ ] Cursor changes to pointing hand when hovering enabled context menu items
- [ ] Disabled items keep default cursor
- [ ] Modify `render_context_menu_item` to set cursor when `enabled` is true

**Notes:**

Before returning `ContextMenuItemResponse`, conditionally add cursor based on `enabled` flag.

### US-004: Add cursor pointer to project rows

Add pointer cursor when hovering project rows in the project list.

**Acceptance Criteria:**

- [ ] Cursor changes to pointing hand when hovering any project row
- [ ] Modify `render_project_row` to add cursor to response

**Notes:**

At line ~7127, the response is created. Add cursor indicator before using response for click detection.

### US-005: Add cursor pointer to tab close buttons

Add pointer cursor when hovering the X close button on tabs.

**Acceptance Criteria:**

- [ ] Cursor changes to pointing hand when hovering tab close buttons
- [ ] Only when `close_hovered` is true

**Notes:**

In `render_tab` around line ~4057, when `close_hovered` is true, set output cursor. Use `ui.ctx().output_mut(|o| o.cursor_icon = CursorIcon::PointingHand)`.

### US-006: Skip hover background on disabled context menu items

Disabled context menu items currently show hover background which is misleading. Skip the hover effect for disabled items.

**Acceptance Criteria:**

- [ ] Disabled context menu items do not show hover background
- [ ] Enabled items continue to show hover background normally

**Notes:**

At line ~3520, the condition `if is_hovered` already uses `response.hovered() && enabled`, so this should already work. Verify and fix if needed.

### US-007: Scale up close button on hover

Make the tab close button (X) slightly larger on hover for better visual feedback.

**Acceptance Criteria:**

- [ ] Close button X icon scales up ~15% when hovered
- [ ] Scale applies to the X lines, not the background rect

**Notes:**

At line ~4072, `x_size` is calculated. When `close_hovered`, multiply by 1.15: `let x_size = TAB_CLOSE_BUTTON_SIZE * 0.35 * if close_hovered { 1.15 } else { 1.0 };`